### PR TITLE
Zsh Completions

### DIFF
--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ BIN_DIR = ./bin
 BIN_DIR_OUTPUT = $(BIN_DIR)/release
 PACKAGE_NAME = goto
 
-SCRIPT_NAMES = install uninstall install_utils.sh gotoutils.sh
+SCRIPT_NAMES = install uninstall install_utils.sh gotoutils.sh _goto
 SCRIPT_DEST = $(patsubst %, $(BIN_DIR_OUTPUT)/%, $(SCRIPT_NAMES))
 
 COMPONENT_NAMES = $(SCRIPT_NAMES) $(GOTO_TOOL_NAME)

--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ BIN_DIR = ./bin
 BIN_DIR_OUTPUT = $(BIN_DIR)/release
 PACKAGE_NAME = goto
 
-SCRIPT_NAMES = install uninstall install_utils.sh gotoutils.sh _goto
+SCRIPT_NAMES = install uninstall install_utils.sh utils.sh env.sh
 SCRIPT_DEST = $(patsubst %, $(BIN_DIR_OUTPUT)/%, $(SCRIPT_NAMES))
 
 COMPONENT_NAMES = $(SCRIPT_NAMES) $(GOTO_TOOL_NAME)

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+SCRIPT_PATH=$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P );
+
+source $SCRIPT_PATH/utils.sh
+
+goto_init;
+

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-SCRIPT_PATH=$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P );
-
-source $SCRIPT_PATH/utils.sh
-
+source ~/.goto/utils.sh
 goto_init;
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 source ~/.goto/utils.sh
-goto_init;
+goto-init;
 

--- a/scripts/gotoutils.sh
+++ b/scripts/gotoutils.sh
@@ -71,5 +71,15 @@ function goto_init_bash() {
 }
 
 function goto_init_zsh() {
+	echo "" > /dev/null 2>&1;
 }
 
+function goto_init() {
+	if [ -n $ZSH_VERSION ]; then
+		goto_init_zsh;
+	else
+		goto_init_bash;
+	fi
+}
+
+goto_init;

--- a/scripts/gotoutils.sh
+++ b/scripts/gotoutils.sh
@@ -3,8 +3,8 @@
 
 GOTO_UTILS_DATA_DIR=~/.gotoutils
 GOTO_UTILS_TOOL=$GOTO_UTILS_DATA_DIR/gototool
-
 GOTO_UTILS_TOOL_ACCEPTED_ARGS=("$($GOTO_UTILS_TOOL --accepted-args)");
+
 
 function emulate_goto() {
 	type emulate > /dev/null 2>&1;
@@ -71,7 +71,9 @@ function goto_init_bash() {
 }
 
 function goto_init_zsh() {
-	echo "" > /dev/null 2>&1;
+	#echo "" > /dev/null 2>&1;
+	fpath+="$GOTO_UTILS_DATA_DIR";
+	$GOTO_UTILS_TOOL --completion-zsh > $GOTO_UTILS_DATA_DIR/_goto;
 }
 
 function goto_init() {

--- a/scripts/install
+++ b/scripts/install
@@ -4,7 +4,6 @@
 # date: 5/2/24
 #
 
-
 ## CONSTANTS
 
 SCRIPT_NAME=$(basename $0);

--- a/scripts/install
+++ b/scripts/install
@@ -76,11 +76,7 @@ function main() {
 			exit $?;
 		else
 			printf "Installation complete\n";
-			if [ -n $ZSH_VERSION ]; then
-				printf "Please add \`source ~/.gotoutils/gotoutils.sh; goto_init_zsh;\` in your shell profile\n";
-			else
-				printf "Please add \`source ~/.gotoutils/gotoutils.sh; goto_init_bash;\` in your shell profile\n";
-			fi
+			printf "Please add \`source ~/.gotoutils/gotoutils.sh;\` in your shell profile\n";
 		fi
 	fi
 

--- a/scripts/install
+++ b/scripts/install
@@ -23,7 +23,7 @@ source $SCRIPT_PATH/install_utils.sh
 function help() {
 	printf "usage: $SCRIPT_NAME\n";
 	printf "\n";
-	printf "Creates a gotoutils folder in your home directory and stores all components in it\n";
+	printf "Creates a goto folder in your home directory and stores all components in it\n";
 	printf "\n";
 	printf "Copyright © 2024 Brando. All rights reserved.\n";
 }
@@ -33,13 +33,16 @@ function help() {
 #
 # returns error code
 function install() {
-	local targetpath=~/$GOTO_UTILS_DIR_NAME;
+	#local targetpath=~/$GOTO_UTILS_DIR_NAME;
+	local targetpath=$GOTO_UTILS_DATA_DIR;
 
 	# make the goto utils dir
-	mkdir $targetpath;
 	if [ ! -d $targetpath ]; then
-		printf "error: could not create $targetpath\n";
-		return 1;
+		mkdir $targetpath;
+		if [ $? -ne 0 ]; then
+			printf "error: could not create $targetpath\n";
+			return 1;
+		fi
 	fi
 
 	# copy components
@@ -54,6 +57,11 @@ function install() {
 			return 2;
 		fi
 	done
+
+	# create the completions file for zsh
+	if [ -n $ZSH_VERSION ]; then
+		goto-completion-zsh-reload;
+	fi
 
 	return 0;
 }
@@ -76,7 +84,8 @@ function main() {
 			exit $?;
 		else
 			printf "Installation complete\n";
-			printf "Please add \`source ~/.gotoutils/gotoutils.sh;\` in your shell profile\n";
+			printf "Please add the following to your shell profile:\n";
+			printf "\`source ~/$GOTO_UTILS_DATA_DIR_NAME/$GOTO_ENV_FILE_NAME;\`\n";
 		fi
 	fi
 

--- a/scripts/install_utils.sh
+++ b/scripts/install_utils.sh
@@ -13,7 +13,6 @@ ARG_HELP="help";
 ARG_HELP_V2="--help";
 ARG_HELP_V3="-h";
 
-#GOTO_UTILS_DIR_NAME=".goto";
 GOTO_UTILS_FILE_NAME="utils.sh";
 GOTO_ENV_FILE_NAME="env.sh";
 

--- a/scripts/install_utils.sh
+++ b/scripts/install_utils.sh
@@ -1,8 +1,11 @@
+#!/bin/bash
 #
 # author: brando
 # date: 4/2/24
 #
 # used by install and uninstall script
+
+SCRIPT_PATH=$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P );
 
 ## CONSTANTS
 
@@ -10,10 +13,14 @@ ARG_HELP="help";
 ARG_HELP_V2="--help";
 ARG_HELP_V3="-h";
 
-GOTO_UTILS_DIR_NAME=".gotoutils";
+#GOTO_UTILS_DIR_NAME=".goto";
+GOTO_UTILS_FILE_NAME="utils.sh";
+GOTO_ENV_FILE_NAME="env.sh";
+
+source $SCRIPT_PATH/utils.sh
 
 # update if there are more things we need to copy over
-GOTO_COMPONENTS=( "gototool" "gotoutils.sh" )
+GOTO_COMPONENTS=( "$GOTO_UTILS_TOOL_NAME" "$GOTO_UTILS_FILE_NAME" "$GOTO_ENV_FILE_NAME" )
 
 ## GLOBALS
 gShowHelp=false;

--- a/scripts/uninstall
+++ b/scripts/uninstall
@@ -22,7 +22,7 @@ source $SCRIPT_PATH/install_utils.sh
 function help() {
 	printf "usage: $SCRIPT_NAME\n";
 	printf "\n";
-	printf "Removes $GOTO_UTILS_DIR_NAME from your home directory\n";
+	printf "Removes $GOTO_UTILS_DATA_DIR from your home directory\n";
 	printf "\n";
 	printf "Copyright © 2024 Brando. All rights reserved.\n";
 }
@@ -32,13 +32,13 @@ function help() {
 #
 # returns error code
 function uninstall() {
-	rm -rfv ~/$GOTO_UTILS_DIR_NAME;
+	rm -rfv $GOTO_UTILS_DATA_DIR;
 	
 	if [ $? -ne 0 ]; then
 		printf "error: rm returned $?\n";
 		return 2;
-	elif [ -d ~/$GOTO_UTILS_DIR_NAME ]; then
-		printf "error: couldn't remove $(~/$GOTO_UTILS_DIR_NAME)\n";
+	elif [ -d $GOTO_UTILS_DATA_DIR ]; then
+		printf "error: couldn't remove $GOTO_UTILS_DATA_DIR\n";
 		return 1;
 	fi
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-
-GOTO_UTILS_DATA_DIR=~/.gotoutils
-GOTO_UTILS_TOOL=$GOTO_UTILS_DATA_DIR/gototool
+GOTO_UTILS_DATA_DIR_NAME=.goto
+GOTO_UTILS_DATA_DIR=~/$GOTO_UTILS_DATA_DIR_NAME
+GOTO_UTILS_TOOL_NAME=gototool
+GOTO_UTILS_TOOL=$GOTO_UTILS_DATA_DIR/$GOTO_UTILS_TOOL_NAME
 GOTO_UTILS_TOOL_ACCEPTED_ARGS=("$($GOTO_UTILS_TOOL --accepted-args)");
-
+GOTO_COMPLETIONS_ZSH_FILE_NAME="_goto";
 
 function emulate_goto() {
 	type emulate > /dev/null 2>&1;
@@ -71,9 +72,11 @@ function goto_init_bash() {
 }
 
 function goto_init_zsh() {
-	#echo "" > /dev/null 2>&1;
 	fpath+="$GOTO_UTILS_DATA_DIR";
-	$GOTO_UTILS_TOOL --completion-zsh > $GOTO_UTILS_DATA_DIR/_goto;
+}
+
+function goto-completion-zsh-reload() {
+	$GOTO_UTILS_TOOL --completion-zsh > $GOTO_UTILS_DATA_DIR/$GOTO_COMPLETIONS_ZSH_FILE_NAME;
 }
 
 function goto_init() {
@@ -84,4 +87,3 @@ function goto_init() {
 	fi
 }
 
-goto_init;

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -6,7 +6,7 @@ GOTO_UTILS_TOOL_NAME=gototool
 GOTO_UTILS_TOOL=$GOTO_UTILS_DATA_DIR/$GOTO_UTILS_TOOL_NAME
 GOTO_COMPLETIONS_ZSH_FILE_NAME="_goto";
 
-function emulate_goto() {
+function __goto_emulate() {
 	type emulate > /dev/null 2>&1;
 	if [ $? -eq 0 ]; then
 		emulate $@;
@@ -14,8 +14,8 @@ function emulate_goto() {
 }
 
 function goto() {
-	old=$(emulate_goto);
-	emulate_goto bash;
+	old=$(__goto_emulate);
+	__goto_emulate bash;
 	cont=true;
 	p=$($GOTO_UTILS_TOOL $@);
 	error=$?;
@@ -54,7 +54,7 @@ function goto() {
 		fi
 	fi
 	
-	emulate_goto $old;
+	__goto_emulate $old;
 	return $error;
 }
 
@@ -66,11 +66,11 @@ function __goto_completion() {
 	fi
 }
 
-function goto_init_bash() {
+function goto-init-bash() {
 	complete -F __goto_completion goto
 }
 
-function goto_init_zsh() {
+function goto-init-zsh() {
 	fpath+="$GOTO_UTILS_DATA_DIR";
 }
 
@@ -78,13 +78,13 @@ function goto-completion-zsh-reload() {
 	$GOTO_UTILS_TOOL --completion-zsh > $GOTO_UTILS_DATA_DIR/$GOTO_COMPLETIONS_ZSH_FILE_NAME;
 }
 
-function goto_init() {
+function goto-init() {
 	GOTO_UTILS_TOOL_ACCEPTED_ARGS=("$($GOTO_UTILS_TOOL --accepted-args)");
 
 	if [ -n $ZSH_VERSION ]; then
-		goto_init_zsh;
+		goto-init-zsh;
 	else
-		goto_init_bash;
+		goto-init-bash;
 	fi
 }
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -4,7 +4,6 @@ GOTO_UTILS_DATA_DIR_NAME=.goto
 GOTO_UTILS_DATA_DIR=~/$GOTO_UTILS_DATA_DIR_NAME
 GOTO_UTILS_TOOL_NAME=gototool
 GOTO_UTILS_TOOL=$GOTO_UTILS_DATA_DIR/$GOTO_UTILS_TOOL_NAME
-GOTO_UTILS_TOOL_ACCEPTED_ARGS=("$($GOTO_UTILS_TOOL --accepted-args)");
 GOTO_COMPLETIONS_ZSH_FILE_NAME="_goto";
 
 function emulate_goto() {
@@ -80,6 +79,8 @@ function goto-completion-zsh-reload() {
 }
 
 function goto_init() {
+	GOTO_UTILS_TOOL_ACCEPTED_ARGS=("$($GOTO_UTILS_TOOL --accepted-args)");
+
 	if [ -n $ZSH_VERSION ]; then
 		goto_init_zsh;
 	else

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -81,7 +81,7 @@ function goto-completion-zsh-reload() {
 function goto-init() {
 	GOTO_UTILS_TOOL_ACCEPTED_ARGS=("$($GOTO_UTILS_TOOL --accepted-args)");
 
-	if [ -n $ZSH_VERSION ]; then
+	if [ "$ZSH_VERSION" != "" ]; then
 		goto-init-zsh;
 	else
 		goto-init-bash;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,12 +24,23 @@ static ARG_REMOVE: &'static str = "--remove";
 static ARG_HELP: &'static str = "--help";
 static ARG_SHOWALLKEYPAIRS: &'static str = "--show-all";
 static ARG_GETVERSION: &'static str = "--version";
+
+/**
+ * outputs all args in a space-delimited list
+ */
 static ARG_ACCEPTEDARGS: &'static str = "--accepted-args";
 
 /**
  * this argument expects a parameter
  */
 static ARG_GETSUGKEYS: &'static str = "--show-suggested-keys";
+
+/**
+ * outputs the content for zsh-completions
+ *
+ * https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org#table-of-contents
+ */
+static ARG_COMPLETION_ZSH: &'static str = "--completion-zsh";
 
 static GOTO_UTILS_DIRNAME_TEST: &'static str = ".gotoutils_test";
 static GOTO_UTILS_DIRNAME_RELEASE: &'static str = ".gotoutils";
@@ -58,6 +69,23 @@ fn help() {
 
     println!();
     println!("version: {}, 2024", version());
+}
+
+/**
+ * writes content for the completion file: _goto
+ */
+fn completion_zsh() {
+    println!("#compdef goto");
+    println!("local -a subcmds");
+    println!("subcmds=( \
+        '{ARG_HELP}:gets help' \
+        '{ARG_GETPATH_PREV}:cd back into previous directory' \
+        '{ARG_GETKEYS}:returns all keys for the path' \
+        '{ARG_ADD}:adds key/path pair' \
+        '{ARG_REMOVE}:removes key/path pair via key' \
+        '{ARG_SHOWALLKEYPAIRS}:shows all key pairs' \
+    )");
+    println!("_describe 'goto' subcmds");
 }
 
 fn main() {
@@ -90,6 +118,8 @@ fn run() -> Result<(), i32> {
         println!("{}", version());
     } else if args[1].eq(ARG_ACCEPTEDARGS) {
         print_all_accepted_args()?;
+    } else if args[1].eq(ARG_COMPLETION_ZSH) {
+        completion_zsh();
     } else {
         print_path_for_key(&args)?;
     }
@@ -102,7 +132,8 @@ fn print_all_accepted_args() -> Result<(), i32> {
     "{ARG_GETPATH_PREV} {ARG_GETKEYS} \
     {ARG_GETSUGKEYS} {ARG_ADD} {ARG_REMOVE} \
     {ARG_HELP} {ARG_SHOWALLKEYPAIRS} \
-    {ARG_GETVERSION} {ARG_ACCEPTEDARGS}");
+    {ARG_GETVERSION} {ARG_ACCEPTEDARGS} \
+    {ARG_COMPLETION_ZSH}");
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,18 +76,35 @@ fn help() {
  *
  * https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org
  */
-fn completion_zsh() {
+fn completion_zsh() -> Result<(), i32> {
     println!("#compdef goto");
     println!("local -a subcmds");
-    println!("subcmds=( ");
-    println!("'{ARG_HELP}:gets help' ");
-    println!("'{ARG_GETPATH_PREV}:cd back into previous directory' ");
-    println!("'{ARG_GETKEYS}:returns all keys for the path' "
-    println!("'{ARG_ADD}:adds key/path pair' \
-    println!("'{ARG_REMOVE}:removes key/path pair via key' \
-    println!("'{ARG_SHOWALLKEYPAIRS}:shows all key pairs' \
+    println!("subcmds=( \\");
+
+    match Config::new(&goto_key_paths_file_path()) {
+        Err(e) => {
+            eprintln!("{}", e);
+        } Ok(conf) => {
+            for key_path_pair in conf.entries() {
+                if !key_path_pair.is_valid() {
+                    break;
+                } else {
+                    println!("{}:{}", key_path_pair.key(), key_path_pair.path());
+                }
+            }
+        }
+    }
+ 
+    println!("'{ARG_HELP}:gets help' \\");
+    println!("'{ARG_GETPATH_PREV}:cd back into previous directory' \\");
+    println!("'{ARG_GETKEYS}:returns all keys for the path' \\");
+    println!("'{ARG_ADD}:adds key/path pair' \\");
+    println!("'{ARG_REMOVE}:removes key/path pair via key' \\");
+    println!("'{ARG_SHOWALLKEYPAIRS}:shows all key pairs' \\");
     println!(")");
     println!("_describe 'goto' subcmds");
+
+    Ok(())
 }
 
 fn main() {
@@ -121,7 +138,7 @@ fn run() -> Result<(), i32> {
     } else if args[1].eq(ARG_ACCEPTEDARGS) {
         print_all_accepted_args()?;
     } else if args[1].eq(ARG_COMPLETION_ZSH) {
-        completion_zsh();
+        completion_zsh()?;
     } else {
         print_path_for_key(&args)?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,13 +19,17 @@ use std::fs;
 
 static ARG_GETPATH_PREV: &'static str = "--prev";
 static ARG_GETKEYS: &'static str = "--show-keys";
-static ARG_GETSUGKEYS: &'static str = "--show-suggested-keys";
 static ARG_ADD: &'static str = "--add";
 static ARG_REMOVE: &'static str = "--remove";
 static ARG_HELP: &'static str = "--help";
 static ARG_SHOWALLKEYPAIRS: &'static str = "--show-all";
 static ARG_GETVERSION: &'static str = "--version";
 static ARG_ACCEPTEDARGS: &'static str = "--accepted-args";
+
+/**
+ * this argument expects a parameter
+ */
+static ARG_GETSUGKEYS: &'static str = "--show-suggested-keys";
 
 static GOTO_UTILS_DIRNAME_TEST: &'static str = ".gotoutils_test";
 static GOTO_UTILS_DIRNAME_RELEASE: &'static str = ".gotoutils";
@@ -37,17 +41,19 @@ fn version() -> String {
     return env!("CARGO_PKG_VERSION").to_owned();
 }
 
+/**
+ * this help is in the context of the script wrapper function: goto
+ */
 fn help() {
     let tool_name = "goto";
     println!("usage: {tool_name} <arg>");
     println!("arguments:");
     println!("");
-    //println!("{tool_name} {ARG_GETPATH} <key> = returns path for a key");
-    println!("{tool_name} {ARG_GETPATH_PREV} = returns the previous path that was queried");
+    println!("{tool_name} {ARG_GETPATH_PREV} = cd back into previous directory");
     println!("{tool_name} {ARG_GETKEYS} <path> = returns all keys for the path");
-    println!("{tool_name} {ARG_GETSUGKEYS} = returns suggested keys");
     println!("{tool_name} {ARG_ADD} <key> <path> = adds key/path pair");
     println!("{tool_name} {ARG_REMOVE} <key> = removes key/path pair via key");
+    println!("{tool_name} {ARG_SHOWALLKEYPAIRS} = shows all key pairs");
     println!("{tool_name} {ARG_HELP} = gets help");
 
     println!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ static ARG_GETSUGKEYS: &'static str = "--show-suggested-keys";
 static ARG_COMPLETION_ZSH: &'static str = "--completion-zsh";
 
 static GOTO_UTILS_DIRNAME_TEST: &'static str = ".gotoutils_test";
-static GOTO_UTILS_DIRNAME_RELEASE: &'static str = ".gotoutils";
+static GOTO_UTILS_DIRNAME_RELEASE: &'static str = ".goto";
 static GOTO_UTILS_DIRNAME_KEYPATHS: &'static str = "keypaths";
 static GOTO_UTILS_DIRNAME_HISTORY: &'static str = "history";
 static GOTO_UTILS_DIRNAME: &'static str = if cfg!(test) { GOTO_UTILS_DIRNAME_TEST } else { GOTO_UTILS_DIRNAME_RELEASE };

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ fn completion_zsh() -> Result<(), i32> {
                 if !key_path_pair.is_valid() {
                     break;
                 } else {
-                    println!("{}:{}", key_path_pair.key(), key_path_pair.path());
+                    println!("'{}:{}' \\", key_path_pair.key(), key_path_pair.path());
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,18 +73,20 @@ fn help() {
 
 /**
  * writes content for the completion file: _goto
+ *
+ * https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org
  */
 fn completion_zsh() {
     println!("#compdef goto");
     println!("local -a subcmds");
-    println!("subcmds=( \
-        '{ARG_HELP}:gets help' \
-        '{ARG_GETPATH_PREV}:cd back into previous directory' \
-        '{ARG_GETKEYS}:returns all keys for the path' \
-        '{ARG_ADD}:adds key/path pair' \
-        '{ARG_REMOVE}:removes key/path pair via key' \
-        '{ARG_SHOWALLKEYPAIRS}:shows all key pairs' \
-    )");
+    println!("subcmds=( ");
+    println!("'{ARG_HELP}:gets help' ");
+    println!("'{ARG_GETPATH_PREV}:cd back into previous directory' ");
+    println!("'{ARG_GETKEYS}:returns all keys for the path' "
+    println!("'{ARG_ADD}:adds key/path pair' \
+    println!("'{ARG_REMOVE}:removes key/path pair via key' \
+    println!("'{ARG_SHOWALLKEYPAIRS}:shows all key pairs' \
+    println!(")");
     println!("_describe 'goto' subcmds");
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,6 @@ use crate::keypath::KeyPath;
 use crate::config::Config;
 use std::fs;
 
-//static ARG_GETPATH: &'static str = "getpath";
 static ARG_GETPATH_PREV: &'static str = "--prev";
 static ARG_GETKEYS: &'static str = "--show-keys";
 static ARG_GETSUGKEYS: &'static str = "--show-suggested-keys";
@@ -39,8 +38,7 @@ fn version() -> String {
 }
 
 fn help() {
-    let args: Vec<String> = env::args().collect();
-    let tool_name = Path::new(&args[0]).file_stem().unwrap().to_str().unwrap();
+    let tool_name = "goto";
     println!("usage: {tool_name} <arg>");
     println!("arguments:");
     println!("");

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,5 @@
 0.2
-[] auto completion for zsh
+[x] auto completion for zsh
     - https://www.olets.dev/posts/writing-tab-completions-for-zsh-commands-can-be-straightforward/
 
 0.1

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,6 @@
 0.2
 [] auto completion for zsh
+    - https://www.olets.dev/posts/writing-tab-completions-for-zsh-commands-can-be-straightforward/
 
 0.1
 [x] ability to goto the previous directory


### PR DESCRIPTION
* changes the goto utilities folder from `~/.gotoutils` to `~/.goto` 
* changes the source file for the goto environment
* adds `--completion-zsh` that outputs the zsh-completion content see: https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org